### PR TITLE
Remove warning against support for 2018 robots

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,6 @@ found at http://robotpy-ctre.readthedocs.io/
 **NOTE**: The RobotPy project is not associated with or endorsed by Cross The
 Road Electronics.
 
-**NOTE**: This repository doesn't work for 2018 Robots yet. Soon!
-
 Setup (simulator)
 -----------------
 


### PR DESCRIPTION
It seems the necessary updates have been made, so I thought I'd take this bit out.