### PR TITLE
Fix enums on roboRIO not matching sim

### DIFF
--- a/gen/gen_enum_pybind11.cpp.j2
+++ b/gen/gen_enum_pybind11.cpp.j2
@@ -3,7 +3,7 @@
 {% for enum in header.enums %}
   py::enum_<{{ enum.namespace }}{{ enum.name }}>(m, "{{ enum.name }}")
   {% for val in enum['values'] %}
-    .value("{{ val.name }}", {{ enum.namespace }}{{ enum.name }}::{{ val.name }})
+    .value("{{ val.x_name }}", {{ enum.namespace }}{{ enum.name }}::{{ val.name }})
   {% endfor %};
 
 {% endfor %}


### PR DESCRIPTION
This fixes a large number of enums being prefixed with the enum name only on the robot.