### PR TITLE
docs: Use autoclass for WPI motor controllers and CANifier

### DIFF
--- a/docs/api_canifier.rst
+++ b/docs/api_canifier.rst
@@ -2,7 +2,7 @@
 CANifier
 ========
 
-.. automodule:: ctre.canifier
+.. autoclass:: ctre.CANifier
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/api_talonsrx.rst
+++ b/docs/api_talonsrx.rst
@@ -2,7 +2,7 @@
 TalonSRX
 ========
 
-.. automodule:: ctre.wpi_talonsrx
+.. autoclass:: ctre.WPI_TalonSRX
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/api_victorspx.rst
+++ b/docs/api_victorspx.rst
@@ -1,7 +1,7 @@
 VictorSPX
 =========
 
-.. automodule:: ctre.wpi_victorspx
+.. autoclass:: ctre.WPI_VictorSPX
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Make it clear in the docs that ctre.WPI_TalonSRX, ctre.WPI_VictorSPX, and ctre.CANifier are acceptable spellings.

This doesn't touch the PigeonIMU docs, since that module still needs to be fixed up...