### PR TITLE
Split controller-specific enums from base

### DIFF
--- a/ctre/basemotorcontroller.py
+++ b/ctre/basemotorcontroller.py
@@ -28,13 +28,8 @@ from ._impl import (
     MotController,
     ControlMode,
     NeutralMode,
-    FeedbackDevice,
-    StatusFrame,
-    StatusFrameEnhanced,
     VelocityMeasPeriod,
-    RemoteLimitSwitchSource,
     LimitSwitchNormal,
-    LimitSwitchSource,
     MotionProfileStatus,
     Faults,
     StickyFaults,
@@ -49,17 +44,12 @@ class BaseMotorController(MotController):
     """Base motor controller features for all CTRE CAN motor controllers."""
     
     ControlMode = ControlMode
-    FeedbackDevice = FeedbackDevice
     LimitSwitchNormal = LimitSwitchNormal
-    LimitSwitchSource = LimitSwitchSource
     NeutralMode = NeutralMode
     ParamEnum = ParamEnum
-    RemoteLimitSwitchSource = RemoteLimitSwitchSource
-    StatusFrame = StatusFrame
-    StatusFrameEnhanced = StatusFrameEnhanced
     VelocityMeasPeriod = VelocityMeasPeriod
 
-    def __init__(self, arbId: int):
+    def __init__(self, arbId: int) -> None:
         """
         Constructor for motor controllers.
         

--- a/ctre/talonsrx.py
+++ b/ctre/talonsrx.py
@@ -22,7 +22,9 @@
 # (INCLUDING NEGLIGENCE), BREACH OF WARRANTY, OR OTHERWISE
 #----------------------------------------------------------------------------
 import hal
+
 from .basemotorcontroller import BaseMotorController
+from ._impl import FeedbackDevice, LimitSwitchSource, StatusFrameEnhanced
 
 
 __all__ = ['TalonSRX']
@@ -31,8 +33,13 @@ __all__ = ['TalonSRX']
 class TalonSRX(BaseMotorController):
     """CTRE Talon SRX Motor Controller when used on CAN Bus.
     
-    Don't use this directly, use :class:`.WPI_TalonSRX`"""
+    We don't recommend using this directly. Use :class:`.WPI_TalonSRX` instead.
+    """
 
-    def __init__(self, deviceNumber):
+    FeedbackDevice = FeedbackDevice
+    LimitSwitchSource = LimitSwitchSource
+    StatusFrameEnhanced = StatusFrameEnhanced
+
+    def __init__(self, deviceNumber: int) -> None:
         super().__init__(deviceNumber | 0x02040000)
         hal.report(hal.UsageReporting.kResourceType_CANTalonSRX, deviceNumber + 1)

--- a/ctre/victorspx.py
+++ b/ctre/victorspx.py
@@ -22,18 +22,25 @@
 # (INCLUDING NEGLIGENCE), BREACH OF WARRANTY, OR OTHERWISE
 #----------------------------------------------------------------------------
 import hal
+
 from .basemotorcontroller import BaseMotorController
+from ._impl import RemoteFeedbackDevice, RemoteLimitSwitchSource, StatusFrame
 
 
 __all__ = ['VictorSPX']
 
 
-class VictorSPX (BaseMotorController):
+class VictorSPX(BaseMotorController):
     """VEX Victor SPX Motor Controller when used on CAN Bus.
     
-    Don't use this directly, use :class:`.WPI_VictorSPX`"""
+    We don't recommend using this directly. Use :class:`.WPI_VictorSPX` instead.
+    """
 
-    def __init__(self, deviceNumber: int):
+    RemoteFeedbackDevice = RemoteFeedbackDevice
+    RemoteLimitSwitchSource = RemoteLimitSwitchSource
+    StatusFrame = StatusFrame
+
+    def __init__(self, deviceNumber: int) -> None:
         """Constructor
 
         :param deviceNumber:


### PR DESCRIPTION
This removes the Remote enums from TalonSRX, and the TalonSRX-specific
enums for local stuff from VictorSPX.

Also improve the note encouraging the use of the WPI wrappers.