### PR TITLE
Export non-WPI motor controllers

### DIFF
--- a/ctre/__init__.py
+++ b/ctre/__init__.py
@@ -1,4 +1,5 @@
-
+from .talonsrx import TalonSRX
+from .victorspx import VictorSPX
 from .wpi_talonsrx import WPI_TalonSRX
 from .wpi_victorspx import WPI_VictorSPX
 from .canifier import CANifier
@@ -9,6 +10,8 @@ from ._impl import (
     ErrorCode,
     FeedbackDevice,
     RemoteFeedbackDevice,
+    LimitSwitchSource,
+    LimitSwitchNormal,
     NeutralMode,
 )
 


### PR DESCRIPTION
Also export the limit switch enums at the top-level.

Doing this because, uh, the overhead of the WPI wrapper isn't great it seems.
(I still wouldn't necessarily recommend teams actually do this...)