### PR TITLE
Move TalonSRX-specific enums from base to TalonSRX

### DIFF
--- a/ctre/basemotorcontroller.py
+++ b/ctre/basemotorcontroller.py
@@ -29,10 +29,8 @@ from ._impl import (
     DemandType,
     ErrorCode,
     Faults,
-    FeedbackDevice,
     FollowerType,
     LimitSwitchNormal,
-    LimitSwitchSource,
     MotController,
     MotionProfileStatus,
     NeutralMode,
@@ -41,7 +39,6 @@ from ._impl import (
     RemoteLimitSwitchSource,
     RemoteSensorSource,
     StatusFrame,
-    StatusFrameEnhanced,
     StickyFaults,
     VelocityMeasPeriod,
 )
@@ -55,16 +52,13 @@ class BaseMotorController(MotController):
     
     ControlMode = ControlMode
     DemandType = DemandType
-    FeedbackDevice = FeedbackDevice
     LimitSwitchNormal = LimitSwitchNormal
-    LimitSwitchSource = LimitSwitchSource
     NeutralMode = NeutralMode
     ParamEnum = ParamEnum
     RemoteFeedbackDevice = RemoteFeedbackDevice
     RemoteLimitSwitchSource = RemoteLimitSwitchSource
     RemoteSensorSource = RemoteSensorSource
     StatusFrame = StatusFrame
-    StatusFrameEnhanced = StatusFrameEnhanced
     VelocityMeasPeriod = VelocityMeasPeriod
 
     def __init__(self, arbId: int) -> None:

--- a/ctre/talonsrx.py
+++ b/ctre/talonsrx.py
@@ -24,6 +24,11 @@
 import hal
 
 from .basemotorcontroller import BaseMotorController
+from ._impl import (
+    FeedbackDevice,
+    LimitSwitchSource,
+    StatusFrameEnhanced,
+)
 
 
 __all__ = ['TalonSRX']
@@ -34,6 +39,10 @@ class TalonSRX(BaseMotorController):
     
     We don't recommend using this directly. Use :class:`.WPI_TalonSRX` instead.
     """
+
+    FeedbackDevice = FeedbackDevice
+    LimitSwitchSource = LimitSwitchSource
+    StatusFrameEnhanced = StatusFrameEnhanced
 
     def __init__(self, deviceNumber: int) -> None:
         super().__init__(deviceNumber | 0x02040000)

--- a/docs/api_mot.rst
+++ b/docs/api_mot.rst
@@ -10,6 +10,7 @@ TalonSRX
 
 .. automodule:: ctre.talonsrx
     :members:
+    :undoc-members:
     :show-inheritance:
 
 VictorSPX


### PR DESCRIPTION
These enums are not intended/cannot be used with VictorSPX, so these don't belong in BaseMotorController.