### PR TITLE
Remove Python 3.5 and add 3.8 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 dist: xenial
 
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 install:
   - pip install pytest coverage header2whatever pytest-cov


### PR DESCRIPTION
Based on robotpy/robotpy-wpilib#606