### PR TITLE
Bump to Phoenix 5.21.2

### DIFF
--- a/gen/Animation.yml
+++ b/gen/Animation.yml
@@ -11,8 +11,10 @@ classes:
       Animation:
       SetSpeed:
       SetNumLed:
+      SetLedOffset:
       GetBaseStandardAnimation:
       GetBaseTwoSizeAnimation:
       GetAnimationIdx:
       GetSpeed:
       GetNumLed:
+      GetLedOffset:

--- a/gen/BaseMotorController.yml
+++ b/gen/BaseMotorController.yml
@@ -264,6 +264,7 @@ classes:
       ConfigClosedLoopPeakOutput:
       ConfigClosedLoopPeriod:
       ConfigAuxPIDPolarity:
+      ConfigureSlot:
       SetIntegralAccumulator:
       GetClosedLoopError:
       GetIntegralAccumulator:

--- a/gen/BaseStandardAnimation.yml
+++ b/gen/BaseStandardAnimation.yml
@@ -10,6 +10,8 @@ classes:
       SetBrightness:
       SetParam4:
       SetParam5:
+      SetReverseDirection:
       GetBrightness:
       GetParam4:
       GetParam5:
+      GetReverseDirection:

--- a/gen/CANdle.yml
+++ b/gen/CANdle.yml
@@ -10,11 +10,13 @@ classes:
       GetCurrent:
       GetTemperature:
       GetVBatModulation:
+      GetMaxSimultaneousAnimationCount:
       Animate:
         overloads:
           Animation&:
           BaseStandardAnimation&:
           BaseTwoSizeAnimation&:
+      ClearAnimation:
       SetLEDs:
       ModulateVBatOutput:
       ConfigLOSBehavior:
@@ -22,6 +24,7 @@ classes:
       ConfigBrightnessScalar:
       ConfigStatusLedState:
       ConfigVBatOutput:
+      configV5Enabled:
       ConfigGetParameter:
       ConfigSetParameter:
       ConfigGetCustomParam:

--- a/gen/CANdle.yml
+++ b/gen/CANdle.yml
@@ -17,6 +17,7 @@ classes:
           BaseStandardAnimation&:
           BaseTwoSizeAnimation&:
       ClearAnimation:
+        ignore: true # TODO
       SetLEDs:
       ModulateVBatOutput:
       ConfigLOSBehavior:

--- a/gen/Pigeon2.yml
+++ b/gen/Pigeon2.yml
@@ -23,6 +23,9 @@ classes:
       EnableCompassDifferent:
       DisableTemperatureCompensationDifferent:
       DisableNoMotionCalibrationDifferent:
+      XAxisGyroErrorDifferent:
+      YAxisGyroErrorDifferent:
+      ZAxisGyroErrorDifferent:
       CustomParam0Different:
       CustomParam1Different:
   Pigeon2:
@@ -40,6 +43,9 @@ classes:
       ConfigMountPoseYaw:
       ConfigMountPosePitch:
       ConfigMountPoseRoll:
+      ConfigXAxisGyroError:
+      ConfigYAxisGyroError:
+      ConfigZAxisGyroError:
       ConfigEnableCompass:
       ConfigDisableTemperatureCompensation:
       ConfigDisableNoMotionCalibration:

--- a/gen/TalonSRX.yml
+++ b/gen/TalonSRX.yml
@@ -45,6 +45,7 @@ classes:
       TalonSRX:
         overloads:
           int:
+          int, std::string&:
           "":
             ignore: true
       ConfigSelectedFeedbackSensor:

--- a/gen/VictorSPX.yml
+++ b/gen/VictorSPX.yml
@@ -66,6 +66,9 @@ classes:
     force_multiple_inheritance: true
     methods:
       VictorSPX:
+        overloads:
+          int:
+          int, std::string&:
       GetPIDConfigs:
       ConfigAllSettings:
       GetAllConfigs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ ignore = false
 artifact_id = "wpiapi-cpp"
 group_id = "com.ctre.phoenix"
 repo_url = "https://maven.ctr-electronics.com/release"
-version = "5.21.1"
+version = "5.21.2"
 libs = ["CTRE_Phoenix_WPI"]
 
 
@@ -34,7 +34,7 @@ ignore = false
 artifact_id = "api-cpp"
 group_id = "com.ctre.phoenix"
 repo_url = "https://maven.ctr-electronics.com/release"
-version = "5.21.1"
+version = "5.21.2"
 libs = ["CTRE_Phoenix"]
 
 
@@ -49,7 +49,7 @@ ignore = false
 artifact_id = "cci"
 group_id = "com.ctre.phoenix"
 repo_url = "https://maven.ctr-electronics.com/release"
-version = "5.21.1"
+version = "5.21.2"
 libs = ["CTRE_PhoenixCCI"]
 
 
@@ -65,7 +65,7 @@ ignore = true
 artifact_id = "wpiapi-cpp-sim"
 group_id = "com.ctre.phoenix.sim"
 repo_url = "https://maven.ctr-electronics.com/release"
-version = "5.21.1"
+version = "5.21.2"
 libs = ["CTRE_Phoenix_WPISim"]
 
 
@@ -80,7 +80,7 @@ ignore = true
 artifact_id = "api-cpp-sim"
 group_id = "com.ctre.phoenix.sim"
 repo_url = "https://maven.ctr-electronics.com/release"
-version = "5.21.1"
+version = "5.21.2"
 libs = ["CTRE_PhoenixSim"]
 
 
@@ -95,7 +95,7 @@ ignore = true
 artifact_id = "cci-sim"
 group_id = "com.ctre.phoenix.sim"
 repo_url = "https://maven.ctr-electronics.com/release"
-version = "5.21.1"
+version = "5.21.2"
 libs = ["CTRE_PhoenixCCISim"]
 
 
@@ -109,7 +109,7 @@ ignore = true
 artifact_id = "simTalonSRX"
 group_id = "com.ctre.phoenix.sim"
 repo_url = "https://maven.ctr-electronics.com/release"
-version = "5.21.1"
+version = "5.21.2"
 libs = ["CTRE_SimTalonSRX"]
 
 
@@ -123,7 +123,7 @@ ignore = true
 artifact_id = "simTalonFX"
 group_id = "com.ctre.phoenix.sim"
 repo_url = "https://maven.ctr-electronics.com/release"
-version = "5.21.1"
+version = "5.21.2"
 libs = ["CTRE_SimTalonFX"]
 
 
@@ -137,7 +137,7 @@ ignore = true
 artifact_id = "simVictorSPX"
 group_id = "com.ctre.phoenix.sim"
 repo_url = "https://maven.ctr-electronics.com/release"
-version = "5.21.1"
+version = "5.21.2"
 libs = ["CTRE_SimVictorSPX"]
 
 
@@ -151,7 +151,7 @@ ignore = true
 artifact_id = "simPigeonIMU"
 group_id = "com.ctre.phoenix.sim"
 repo_url = "https://maven.ctr-electronics.com/release"
-version = "5.21.1"
+version = "5.21.2"
 libs = ["CTRE_SimPigeonIMU"]
 
 
@@ -165,7 +165,7 @@ ignore = true
 artifact_id = "simCANCoder"
 group_id = "com.ctre.phoenix.sim"
 repo_url = "https://maven.ctr-electronics.com/release"
-version = "5.21.1"
+version = "5.21.2"
 libs = ["CTRE_SimCANCoder"]
 
 


### PR DESCRIPTION
https://github.com/CrossTheRoadElec/Phoenix-Releases/releases/tag/v5.21.2.0

[Release notes](https://newsite.ctr-electronics.com/content/release-notes/RELEASE_NOTES.txt):

- Fixed an issue that could cause early config calls to be re-sent shortly after program start.
- Fixed an issue that could cause config calls to not be sent over CANivore if the CANivore disconnects and reconnects.
- Improved shutdown time of the diagnostics server.
- Fixed an issue that could cause the diagnostics shutdown message to print twice.
- [...] added (C++) ConfigureSlot() functions to configure slot params directly.
- Added Status 21 enum to the status frame enum so it can be used for status period setting.
- Fixed CANcoder getSensorInitializationStrategy() to return the correct value.
- To support SocketCAN on non-FRC platforms, non-CAN-FD device constructors now allow specifying the CAN bus string with non-roboRIO libraries.
- Updated CANdle API to support new firmware features/fixes
- Fixed issue where SimCollection did not work for ribbon-cable connected PigeonIMUs