### PR TITLE
Warn about moved sensors classes

### DIFF
--- a/ctre/__init__.py
+++ b/ctre/__init__.py
@@ -200,13 +200,15 @@ from .version import version as __version__
 # backwards compat
 # TODO: remove in 2024
 def __getattr__(name):
-    from . import sensors
+    if name != "sensors":
+        from .sensors import __all__
 
-    if name in sensors.__all__:
-        import warnings
+        if name in __all__:
+            import warnings
+            from . import sensors
 
-        message = f"{__name__}.{name} has moved to {__name__}.sensors"
-        warnings.warn(message, FutureWarning, stacklevel=2)
-        return getattr(sensors, name)
+            message = f"{__name__}.{name} has moved to {__name__}.sensors"
+            warnings.warn(message, FutureWarning, stacklevel=2)
+            return getattr(sensors, name)
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/ctre/__init__.py
+++ b/ctre/__init__.py
@@ -196,6 +196,17 @@ __all__ = [
 
 from .version import version as __version__
 
+
 # backwards compat
 # TODO: remove in 2024
-from .sensors import *
+def __getattr__(name):
+    from . import sensors
+
+    if name in sensors.__all__:
+        import warnings
+
+        message = f"{__name__}.{name} has moved to {__name__}.sensors"
+        warnings.warn(message, FutureWarning, stacklevel=2)
+        return getattr(sensors, name)
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/ctre/__init__.py
+++ b/ctre/__init__.py
@@ -201,9 +201,9 @@ from .version import version as __version__
 # TODO: remove in 2024
 def __getattr__(name):
     if name != "sensors":
-        from .sensors import __all__
+        from .sensors import __all__ as sensors_all
 
-        if name in __all__:
+        if name in sensors_all:
             import warnings
             from . import sensors
 

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1,0 +1,15 @@
+import pytest
+
+import ctre.sensors
+
+
+def test_cancoder():
+    enc = ctre.sensors.CANCoder(0)
+    enc.getPosition()
+
+
+def test_deprecated_import():
+    with pytest.warns(FutureWarning, match="moved"):
+        from ctre import CANCoder
+
+    assert CANCoder is ctre.sensors.CANCoder


### PR DESCRIPTION
[Module `__getattr__` was added in Python 3.7](https://docs.python.org/3/whatsnew/3.7.html#pep-562-customization-of-access-to-module-attributes).